### PR TITLE
Update reload to exit if parseconfig fails

### DIFF
--- a/src/knockd.c
+++ b/src/knockd.c
@@ -406,6 +406,8 @@ void reload(int signum)
 		perror("warning: cannot open logfile");
 	}
 
+	generate_pcap_filter();
+
 	return;
 }
 

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -386,15 +386,21 @@ void reload(int signum)
 	}
 	list_free(doors);
 
-	parseconfig(o_cfg);
-
-	vprint("Closing and re-opening log file: %s\n", o_logfile);
-	logprint("Closing and re-opening log file: %s\n", o_logfile);
+	vprint("Closing log file: %s\n", o_logfile);
+	logprint("Closing log file: %s\n", o_logfile);
 
 	/* close and re-open the log file */
 	if(logfd) {
 		fclose(logfd);
 	}
+
+	if(parseconfig(o_cfg)) {
+		exit(1);
+	}
+
+	vprint("Re-opening log file: %s\n", o_logfile);
+	logprint("Re-opening log file: %s\n", o_logfile);
+
 	logfd = fopen(o_logfile, "a");
 	if(logfd == NULL) {
 		perror("warning: cannot open logfile");

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -389,7 +389,7 @@ void reload(int signum)
 	vprint("Closing log file: %s\n", o_logfile);
 	logprint("Closing log file: %s\n", o_logfile);
 
-	/* close and re-open the log file */
+	/* close the log file */
 	if(logfd) {
 		fclose(logfd);
 	}
@@ -401,11 +401,13 @@ void reload(int signum)
 	vprint("Re-opening log file: %s\n", o_logfile);
 	logprint("Re-opening log file: %s\n", o_logfile);
 
+	/* re-open the log file */
 	logfd = fopen(o_logfile, "a");
 	if(logfd == NULL) {
 		perror("warning: cannot open logfile");
 	}
 
+	/* Fix issue #2 by regenerating the PCAP filter post config file re-read */
 	generate_pcap_filter();
 
 	return;


### PR DESCRIPTION
I spotted that reload didn't exit when parseconfig failed and would continue to run with no knocks configured.

Updated the code to still close the logfile and exit if parseconfig fails.
