### PR TITLE
Makefile fix to install helper script from 0.7.5 correctly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,12 +2,11 @@ AM_CPPFLAGS=-D_DEFAULT_SOURCE
 AM_CFLAGS=-g -Wall -pedantic -fno-exceptions
 
 bin_PROGRAMS = knock
-
 man_MANS = doc/knock.1
 
 if BUILD_KNOCKD
 sbin_PROGRAMS = knockd
-dist_sbin_SCRIPTS = knock_helper_ipt.sh
+dist_sbin_SCRIPTS = src/knock_helper_ipt.sh
 man_MANS += doc/knockd.1
 sysconf_DATA = knockd.conf
 endif
@@ -15,7 +14,7 @@ endif
 dist_doc_DATA = README.md TODO ChangeLog COPYING
 
 knock_SOURCES = src/knock.c
-knockd_SOURCES = src/knockd.c src/list.c src/list.h
+knockd_SOURCES = src/knockd.c src/list.c src/list.h src/knock_helper_ipt.sh
 
 %.1: %.1.in
 	sed -e "s/#VERSION#/$(VERSION)/" $< > $@


### PR DESCRIPTION
Makefile fix to install helper script from 0.7.5 correctly
