### PR TITLE
Remove warning when compiling on OS X (10.5 upwards)

### DIFF
--- a/src/knockd.c
+++ b/src/knockd.c
@@ -18,6 +18,13 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#if __APPLE__
+// In MacOSX 10.5+, the daemon function is deprecated and will give a warning.
+// This nasty hack which is used by Apple themselves in mDNSResponder does
+// the trick.
+#define daemon deprecated_in_osx_10_5_and_up
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -48,6 +55,11 @@
 #include <pcap.h>
 #include <errno.h>
 #include "list.h"
+
+#if __APPLE__
+#undef daemon
+extern int daemon(int, int);
+#endif
 
 static char version[] = "0.7.7";
 


### PR DESCRIPTION
OS X no longer supports daemon() and expects it to be executed from
launchd. As such it creates a compile time warning. Have added in code
that Apple uses itself in mDNSResponder to handle this issue.
