### PR TITLE
0.7.7 fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 VERSION         DESCRIPTION
 -----------------------------------------------------------------------------
+0.7.8         - Fix for Issue #33, #34 and #35 contributed by Alexander
+                Rumyanstev.
 0.7.7         - Fix for Issue #7 & #17 contributed by Michael G�hler.
                 All IPs assigned to a single interface are now listened on.
               - Fix for compile warning on OSX where daemon() is deprecated.
@@ -17,11 +19,11 @@ VERSION         DESCRIPTION
                 - Fixed PCAP filter for PSH flag detection.
               - Patches from Christos Triantafyllidis
                 - Updated FSF address.
-0.7.2         - Patches from Paul Rogers (paul.rogers@flumps.org)
+0.7.2         - Patches from Paul Rogers
                 - Applied missing fixes from issue #16 - OpenBSD build
                   issues, reordering of headers, scoping DLT_LINUX_SLL for
                   Linux only, for -> while loop in sniff() cleanup.
-0.7.1         - Patches from Paul Rogers (paul.rogers@flumps.org)
+0.7.1         - Patches from Paul Rogers
                 - Fixed issue #2 - SIGHUP (reload) now listens for new
                   sequences in the config file.
                 - Fixed issue #26 - knockd now fails if a malformed config

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS=-D_DEFAULT_SOURCE
-AM_CFLAGS=-g -Wall -pedantic -fno-exceptions
+AM_CFLAGS=-g -Wall -pedantic -fno-exceptions -D_BSD_SOURCE
 
 bin_PROGRAMS = knock
 man_MANS = doc/knock.1

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([knock], [0.7.7], [https://github.com/jvinet/knock/issues])
+AC_INIT([knock], [0.7.8], [https://github.com/jvinet/knock/issues])
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign subdir-objects])
 
 AC_CONFIG_HEADER([config.h])

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -62,7 +62,7 @@
 extern int daemon(int, int);
 #endif
 
-static char version[] = "0.7.7";
+static char version[] = "0.7.8";
 
 #define SEQ_TIMEOUT 25 /* default knock timeout in seconds */
 #define CMD_TIMEOUT 10 /* default timeout in seconds between start and stop commands */

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -19,9 +19,10 @@
  */
 
 #if __APPLE__
-// In MacOSX 10.5+, the daemon function is deprecated and will give a warning.
-// This nasty hack which is used by Apple themselves in mDNSResponder does
-// the trick.
+/* In MacOSX 10.5+, the daemon function is deprecated and will give a warning.
+ * This nasty hack which is used by Apple themselves in mDNSResponder does
+ * the trick.
+ */
 #define daemon deprecated_in_osx_10_5_and_up
 #endif
 

--- a/src/knockd.c
+++ b/src/knockd.c
@@ -269,6 +269,9 @@ int main(int argc, char **argv)
 				if((myip = calloc(1, sizeof(ip_literal_t))) == NULL) {
 					perror("malloc");
 					exit(1);
+				} else if ((myip->value = calloc(1,NI_MAXHOST)) == NULL) {
+					perror("malloc");
+					exit(1);
 				} else {
 					if(getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), myip->value, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) != 0) {
 						fprintf(stderr, "error: could not get IP address for %s: %s\n", o_int, strerror(errno));


### PR DESCRIPTION
Fixed Issues #33, #34 and #35

C++ comments causing warning.

Added -D_BSD_SOURCE to CFLAGS in makefile definition.

Fixed SEGFAULT in getnameinfo call.
